### PR TITLE
Add rpm target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,55 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>rpm-maven-plugin</artifactId>
+                <version>2.2.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-rpm</id>
+                        <goals>
+                            <goal>rpm</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <license>Apache License 2.0</license>
+                    <group>Application/Collectors</group>
+                    <release>1%{?dist}</release>
+                    <requires>
+                        <require>appdynamics-machine-agent</require>
+                    </requires>
+                    <defineStatements>
+                        <defineStatement>_unpackaged_files_terminate_build 0</defineStatement>
+                    </defineStatements>
+                    <mappings>
+                        <mapping>
+                            <directory>/opt/appdynamics/machine-agent/monitors/ProcessMonitor</directory>
+                            <filemode>755</filemode>
+                            <username>root</username>
+                            <groupname>root</groupname>
+                            <sources>
+                                <source>
+                                    <location>target/process-monitoring-extension.jar</location>
+                                </source>
+                            </sources>
+                        </mapping>
+                        <mapping>
+                            <directory>/opt/appdynamics/machine-agent/monitors/ProcessMonitor</directory>
+                            <configuration>true</configuration>
+                            <filemode>644</filemode>
+                            <username>root</username>
+                            <groupname>root</groupname>
+                            <sources>
+                                <source>
+                                    <location>target/classes/conf</location>
+                                </source>
+                            </sources>
+                        </mapping>
+                    </mappings>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>


### PR DESCRIPTION
This adds a rpm target to maven.
An rpm is useful with EL variants when orchestration is not available.